### PR TITLE
Highlight demo updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
  "dependencies": {
   "@mdx-js/rollup": "^2.0.0",
   "goober": "2.0.37",
+  "highlight-updates": "^0.0.6",
   "hoofd": "^1.4.0",
   "preact": "^10.6.5",
   "preact-iso": "^2.3.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import { h, render } from 'preact'
+import 'highlight-updates/preact'
 import { setup } from 'goober'
 import { createGlobalStyles } from 'goober/global'
 import { LocationProvider, Router } from 'preact-iso'

--- a/src/pages/posts/vdom-compilers/State-Equality.tsx
+++ b/src/pages/posts/vdom-compilers/State-Equality.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'preact/hooks'
+// @ts-ignore
+import { Highlighter } from 'highlight-updates/preact'
 import { RerenderTracker } from './common'
 
 const Counter = () => {
@@ -23,7 +25,9 @@ const Counter = () => {
 const App = () => {
   return (
     <div style="border: 1px solid black; padding: 4px 8px">
-      <Counter />
+      <Highlighter>
+        <Counter />
+      </Highlighter>
     </div>
   )
 }

--- a/src/pages/posts/vdom-compilers/Strict-Equality.tsx
+++ b/src/pages/posts/vdom-compilers/Strict-Equality.tsx
@@ -1,18 +1,18 @@
 import { useState } from 'preact/hooks'
+// @ts-ignore
+import { Highlighter } from 'highlight-updates/preact'
 import { RerenderTracker } from './common'
 
 const Counter = (props) => {
   const [count, setCount] = useState(0)
 
   return (
-    <div style='padding: 0px 16px'>
+    <div style="padding: 0px 16px">
       <RerenderTracker name={`Counter #${props.i}`} />
       <p>Count: {count}</p>
       <div style="display:flex;">
         <button onClick={() => setCount((c) => c - 1)}>-1</button>
-        <button onClick={() => setCount((c) => c + 1)}>
-          +1
-        </button>
+        <button onClick={() => setCount((c) => c + 1)}>+1</button>
       </div>
     </div>
   )
@@ -22,9 +22,11 @@ const Layout = (props) => {
   const [darkMode, setDarkMode] = useState(false)
 
   return (
-    <main style='padding: 0px 16px'>
-      <RerenderTracker name='Layout' />
-      <button onClick={() => setDarkMode((dark) => !dark)}>set {darkMode ? "Light" : "Dark"} Mode</button>
+    <main style="padding: 0px 16px">
+      <RerenderTracker name="Layout" />
+      <button onClick={() => setDarkMode((dark) => !dark)}>
+        set {darkMode ? 'Light' : 'Dark'} Mode
+      </button>
       {props.children}
     </main>
   )
@@ -33,15 +35,17 @@ const Layout = (props) => {
 const App = () => {
   const [, setRerender] = useState({})
   return (
-    <div style="border: 1px solid black; padding: 4px 8px">
-      <RerenderTracker name='App' />
-      <button onClick={() => setRerender({})}>Rerender App</button>
-      <Layout>
-        <Counter i='1' />
-        <Counter i='2' />
-      </Layout>
-    </div>
+    <Highlighter>
+      <div style="border: 1px solid black; padding: 4px 8px">
+        <RerenderTracker name="App" />
+        <button onClick={() => setRerender({})}>Rerender App</button>
+        <Layout>
+          <Counter i="1" />
+          <Counter i="2" />
+        </Layout>
+      </div>
+    </Highlighter>
   )
 }
 
-export default App;
+export default App

--- a/yarn.lock
+++ b/yarn.lock
@@ -946,6 +946,11 @@ hast-util-whitespace@^2.0.0:
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-2.0.0.tgz#4fc1086467cc1ef5ba20673cb6b03cec3a970f1c"
   integrity sha512-Pkw+xBHuV6xFeJprJe2BBEoDV+AvQySaz3pPDRUs5PNZEMQjpXJJueqrpcHIXxnWTcAGi/UOCgVShlkY6kLoqg==
 
+highlight-updates@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/highlight-updates/-/highlight-updates-0.0.6.tgz#6a527fe2f889734fe1cf1d97c4f820ccfbab845a"
+  integrity sha512-z6wDSdybyl+7fElOe1mep7J7wzgc7G8OVBG+NrHx+hbf4ebh/C9mWY82niqc/AC0DDQ+CGlN4miCNllOQkEKvA==
+
 highlight.js@~11.4.0:
   version "11.4.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.4.0.tgz#34ceadd49e1596ee5aba3d99346cdfd4845ee05a"


### PR DESCRIPTION
Spent the evening extracting out the code from devtools which is responsible for highlighting component updates in the browser. It will only highlight components that are children of a `Highlighter` component. If multiple renders are triggered in a short amount of time the update color will become more red.

Similar to `preact/debug` it works by hooking into our options hooks, which is why we need to import `highlight-updates/preact` as early as possible.

Screenshots:

Multiple clicks on +1:

![Screenshot 2022-02-13 at 23 22 11](https://user-images.githubusercontent.com/1062408/153777775-9d590ea9-1947-4ffa-9a43-a2cb30743e4d.png)

Clicking "Rerender App" once:
![Screenshot 2022-02-13 at 23 21 36](https://user-images.githubusercontent.com/1062408/153777789-3326bee7-3bdf-4334-9c63-8a91389f0b3e.png)

Clicking the theme toggle once:

![Screenshot 2022-02-13 at 23 21 42](https://user-images.githubusercontent.com/1062408/153777801-b96e99a6-0b2d-4ef5-b144-bda6d06af0fa.png)
