### PR TITLE
fix: Missing end backtick in "Fragments" blog post

### DIFF
--- a/src/pages/posts/fragments-in-vdom/index.mdx
+++ b/src/pages/posts/fragments-in-vdom/index.mdx
@@ -123,7 +123,7 @@ DOM:
 
 When we'd switch `<Todos />` to live in front of `<Persons />` we'd have to move all
 three of its Dom-nodes in front of the first DOM-node wrapped with this `Fragment`
-so we'd have to perform `insertBefore(x, <h1>People</h1>) three times. This however
+so we'd have to perform `insertBefore(x, <h1>People</h1>)` three times. This however
 means that we have to store the `firstDomChild` of this `Fragment` to effectively
 perform this operation.
 


### PR DESCRIPTION
Was giving this a read and noticed this tiny typo. Good post!