### PR TITLE
fix: Correct link to `fragments-in-vdom` from `skew-based-diff` post

### DIFF
--- a/src/pages/posts/skew-based-diff/index.mdx
+++ b/src/pages/posts/skew-based-diff/index.mdx
@@ -53,7 +53,7 @@ This means that compared to our old algorithm we'll be executing `2n` in time co
 as we execute the loop twice, the saved DOM-operations are well worth this tradeoff.
 
 > There are a lot of complexities when we look at i.e. `Fragments` in children diffing
-> but we'll leave those out for now, I invite you to read [my other post on that](../fragments-in-vdom/index.mdx).
+> but we'll leave those out for now, I invite you to read [my other post on that](../fragments-in-vdom).
 
 In the following sections we'll go over the code, how it works and how we have certain optimisations in place for
 the common cases.


### PR DESCRIPTION
Simple broken link, though it does expose an issue with our prerendering setup: all paths are passed through [`new URL(path, 'http://localhost')`](https://github.com/preactjs/vite-prerender-plugin/blob/7467489936a05c58e189eecb5eb2a029b588e28c/src/plugins/prerender-plugin.js#L443) which a relative path is going to cause some problems with. Will need to think how to handle that better.

For your use here it just means some extra docs get created:

```
  /blog/fragments-in-vdom [from /blog]
  ...
  /fragments-in-vdom [from /blog/skew-based-diffing]
  /graphqls-missing-feature [from /blog/fragments-in-vdom]
  /persisted-operations [from /blog/graphql-development-workflow]
```