### PR TITLE
Fix phrasing on npm user credential management

### DIFF
--- a/src/pages/posts/secure-npm-publishing/index.mdx
+++ b/src/pages/posts/secure-npm-publishing/index.mdx
@@ -115,7 +115,7 @@ The mental model I use: every additional publisher is another door. Keep the lis
 people who genuinely need it.
 
 An even safer way to go about this is to create a shared npm user, only one, where you
-store the password and 2FA token in a package manager. This user can only come out for
+store the password and 2FA token in a password manager. This user can only come out for
 emergencies. Not having these credentials on a device, not even for the vault would be
 the safest approach.
 


### PR DESCRIPTION
Corrected wording regarding password storage for npm user.