### PR TITLE
Fix broken source citation on Fed up with Belgium post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ yarn-error.log
 # Yarn Integrity file
 .yarn-integrity
 .cache
+.gstack/

--- a/src/pages/posts/fed-up-with-belgium/index.mdx
+++ b/src/pages/posts/fed-up-with-belgium/index.mdx
@@ -94,11 +94,11 @@ multiple of average earnings, which makes the Belgian curve hard to miss.
     transform: 'translateX(-50%)',
   }}
 >
-  Source:{' '}
+  {'Source: '}
   <a href="https://taxpolicy.org.uk/wp-content/assets/oecd_personal_tax_rates_october_2022_5x.html">
-    Tax Policy Associates
+    {'Tax Policy Associates'}
   </a>
-  , OECD personal tax rates, October 2022.
+  {', OECD personal tax rates, October 2022.'}
 </small>
 
 I was in that top bracket for about five of my employed years. I want to be clear


### PR DESCRIPTION
The image source caption on the *Fed up with Belgium* post rendered as three stacked blocks instead of one inline sentence, because MDX wraps literal text sitting on its own line in `<p>` tags and oxfmt (printWidth 80) forces the long-URL `<a>` onto its own line. This expresses the caption text as JSX string expressions so MDX never paragraph-wraps it, keeping the citation on a single inline line no matter how the formatter breaks lines — verified in-browser (one 24px line, zero stray `<p>` elements, and stable under oxfmt). Also adds `.gstack/` to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)